### PR TITLE
enable turning off animations for the target view or the pop label

### DIFF
--- a/Classes/ios/MMPopLabel.h
+++ b/Classes/ios/MMPopLabel.h
@@ -27,7 +27,9 @@
 
 + (MMPopLabel *)popLabelWithText:(NSString *)text;
 - (void)addButton:(UIButton *)button;
-- (void)popAtView:(UIView *)view;
+- (void)popAtView:(UIView *)view
+  animatePopLabel:(BOOL)animatePopLabel
+animateTargetView:(BOOL)animateTargetView;
 - (void)dismiss;
 
 

--- a/Classes/ios/MMPopLabel.h
+++ b/Classes/ios/MMPopLabel.h
@@ -22,6 +22,7 @@
 @property (nonatomic, retain) UIColor *labelTextHighlightColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, retain) UIFont *labelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, retain) UIFont *buttonFont UI_APPEARANCE_SELECTOR;
+@property (nonatomic) BOOL forceArrowDown;
 
 @property (nonatomic, weak) id<MMPopLabelDelegate> delegate;
 

--- a/Classes/ios/MMPopLabel.m
+++ b/Classes/ios/MMPopLabel.m
@@ -186,7 +186,9 @@ animateTargetView:(BOOL)animateTargetView
 
     _arrowType = MMPopLabelTopArrow;
 
-    CGPoint position = CGPointMake(view.center.x, view.center.y + view.frame.size.height / 2 + kMMPopLabelViewPadding);
+    CGRect translatedFrame = [self.superview convertRect:view.frame fromView:view.superview];
+    CGPoint center = CGPointMake(CGRectGetMidX(translatedFrame), CGRectGetMidY(translatedFrame));
+    CGPoint position = CGPointMake(center.x, center.y + translatedFrame.size.height / 2 + kMMPopLabelViewPadding);
     self.center = position;
     if (position.x + (self.frame.size.width / 2) > [UIScreen mainScreen].applicationFrame.size.width) {
         CGFloat diff = (self.frame.size.width + self.frame.origin.x - [UIScreen mainScreen].applicationFrame.size.width) + kMMPopLabelSidePadding;
@@ -211,7 +213,7 @@ animateTargetView:(BOOL)animateTargetView
     self.alpha = 0.0f;
     self.hidden = NO;
     
-    _viewCenter = CGPointMake(view.center.x - self.frame.origin.x - 8, view.center.y);
+    _viewCenter = CGPointMake(center.x - self.frame.origin.x - 8, center.y);
     [self setNeedsDisplay];
     
     if (animatePopLabel || animateTargetView) {

--- a/Classes/ios/MMPopLabel.m
+++ b/Classes/ios/MMPopLabel.m
@@ -179,6 +179,8 @@ typedef enum : NSUInteger {
 
 
 - (void)popAtView:(UIView *)view
+  animatePopLabel:(BOOL)animatePopLabel
+animateTargetView:(BOOL)animateTargetView
 {
     if (self.hidden == NO) return;
 
@@ -212,26 +214,31 @@ typedef enum : NSUInteger {
     _viewCenter = CGPointMake(view.center.x - self.frame.origin.x - 8, view.center.y);
     [self setNeedsDisplay];
     
-    self.transform = CGAffineTransformMakeScale(0, 0);
-    view.transform = CGAffineTransformMakeScale(0, 0);
-    [UIView animateKeyframesWithDuration:duration/6.0f delay:delay options:0 animations:^{
-        self.center = centerPoint;
-        self.alpha = 1.0f;
-        self.transform = CGAffineTransformMakeScale(1.2, 1.2);
-        view.transform = CGAffineTransformMakeScale(1.2, 1.2);
-    } completion:^(BOOL finished) {
-        [UIView animateKeyframesWithDuration:duration/6.0f delay:0 options:0 animations:^{
-            self.transform = CGAffineTransformMakeScale(0.9, 0.9);
-            view.transform = CGAffineTransformMakeScale(0.9, 0.9);
+    if (animatePopLabel || animateTargetView) {
+        if (animatePopLabel) self.transform = CGAffineTransformMakeScale(0, 0);
+        if (animateTargetView) view.transform = CGAffineTransformMakeScale(0, 0);
+        [UIView animateKeyframesWithDuration:duration/6.0f delay:delay options:0 animations:^{
+            self.center = centerPoint;
+            self.alpha = 1.0f;
+            self.transform = CGAffineTransformMakeScale(1.2, 1.2);
+            if (animateTargetView) view.transform = CGAffineTransformMakeScale(1.2, 1.2);
         } completion:^(BOOL finished) {
             [UIView animateKeyframesWithDuration:duration/6.0f delay:0 options:0 animations:^{
-                self.transform = CGAffineTransformMakeScale(1, 1);
-                view.transform = CGAffineTransformMakeScale(1, 1);
+                if (animatePopLabel) self.transform = CGAffineTransformMakeScale(0.9, 0.9);
+                if (animateTargetView) view.transform = CGAffineTransformMakeScale(0.9, 0.9);
             } completion:^(BOOL finished) {
-                // completion block empty?
+                [UIView animateKeyframesWithDuration:duration/6.0f delay:0 options:0 animations:^{
+                    if (animatePopLabel) self.transform = CGAffineTransformMakeScale(1, 1);
+                    if (animateTargetView) view.transform = CGAffineTransformMakeScale(1, 1);
+                } completion:^(BOOL finished) {
+                    // completion block empty?
+                }];
             }];
         }];
-    }];
+    } else {
+      self.center = centerPoint;
+      self.alpha = 1.0;
+    }
 }
 
 

--- a/Classes/ios/MMPopLabel.m
+++ b/Classes/ios/MMPopLabel.m
@@ -198,10 +198,11 @@ animateTargetView:(BOOL)animateTargetView
         position = CGPointMake(view.center.x + diff, view.center.y + view.frame.size.height / 2);
     }
     
-    if (self.frame.origin.y + self.frame.size.height > [UIScreen mainScreen].applicationFrame.size.height) {
-        _arrowType = MMPopLabelBottomArrow;
-        position = CGPointMake(position.x,
-                               [UIScreen mainScreen].applicationFrame.size.height - (self.frame.size.height + view.frame.size.height + kMMPopLabelViewPadding));
+    if (self.frame.origin.y + self.frame.size.height > [UIScreen mainScreen].applicationFrame.size.height
+        || self.forceArrowDown) {
+      _arrowType = MMPopLabelBottomArrow;
+      position = CGPointMake(position.x,
+                             translatedFrame.origin.y - (self.frame.size.height + kMMPopLabelViewPadding));
     }
 
     CGPoint centerPoint = CGPointMake(position.x, position.y + self.frame.size.height / 2);

--- a/MMPopLabel.podspec
+++ b/MMPopLabel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MMPopLabel"
-  s.version          = "0.1.1"
+  s.version          = "0.1.2"
   s.summary          = "MMPopLabel is a tooltip control for iOS, with optional buttons"
   s.description      = <<-DESC
 MMPopLabel is a tooltip control for iOS, useful for tutorials.


### PR DESCRIPTION
This diff adds bools to the popAtView call for animating the target and poplabel.  I have an instance where I don't want the target view to bounce, but I thought it would be useful to generalize it to not having either view animated as well.