### PR TITLE
Fixed positioning bug where MMPopLabel would not work for UIBarButtonIte...

### DIFF
--- a/Classes/ios/MMPopLabel.m
+++ b/Classes/ios/MMPopLabel.m
@@ -202,8 +202,8 @@ typedef enum : NSUInteger {
     if (self.hidden == NO) return;
 
     CGPoint center = view.center;
-    if ([[view superview] superview] != self.window) {
-        center = [self.window convertPoint:view.center fromView:view];
+    if (view.superview != self.superview) {
+        center = [self.superview convertPoint:center fromView:view.superview];
     }
     self.center = center;
 


### PR DESCRIPTION
Hi,

I did a change regarding the way the center position of the pop label is computed. Previously it did not work to show a pop label against a UIBarButtonItem if the latter was inside a navigation bar. With this change, the existing example is still working + if you add the pop label to 'self.navigationController.view' then you can get the pop label point at button item of the nav bar.

Kind regards.
Patrick
