### PR TITLE
checks if delegate implements optional protocol selectors

### DIFF
--- a/Classes/ios/MMPopLabel.m
+++ b/Classes/ios/MMPopLabel.m
@@ -306,7 +306,7 @@ typedef enum : NSUInteger {
         self.alpha = 0.0f;
     } completion:^(BOOL finished) {
         self.hidden = YES;
-        [_delegate dismissedPopLabel:self];
+        if([_delegate respondsToSelector:@selector(dismissedPopLabel:)]) [_delegate dismissedPopLabel:self];
     }];
 }
 
@@ -350,7 +350,7 @@ typedef enum : NSUInteger {
 - (void)buttonPressed:(id)sender
 {
     UIButton *button = (UIButton *)sender;
-    if (_delegate != nil) {
+    if ([_delegate respondsToSelector:@selector(didPressButtonForPopLabel:atIndex:)]) {
         [_delegate didPressButtonForPopLabel:self atIndex:button.tag];
     }
     [self dismiss];


### PR DESCRIPTION
prevents an unrecognized selector being called on your delegate
