### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Check the *MMPopLabelAnimationOptions* enumeration for more options.
 
 ## Requirements
 
-* iOS 7.0+ and XCode 5.1+
+* iOS 7.0+ and Xcode 5.1+
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
